### PR TITLE
Fix error in README: web3.Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ var Pudding = require("ether-pudding");
 Pudding.setWeb3(web3);
 
 // Set the provider, as you would normally. 
-web3.setProvider(new Web3.Providers.HttpProvider("http://localhost:8545"));
+web3.setProvider(new Web3.providers.HttpProvider("http://localhost:8545"));
 
 var MyContract = Pudding.whisk({
   abi: abi, 


### PR DESCRIPTION
`Web3.Providers` should be `Web3.providers`. I was running into errors when I copied this code from the docs.