### PR TITLE
Passing contract.path to m._compile

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -46,7 +46,7 @@ var PuddingLoader = {
         // Load file without require, to avoid caching.
         var Module = module.constructor;
         var m = new Module();
-        m._compile(contract.code);
+        m._compile(contract.code, contract.file);
 
         factories.push(m.exports);
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./index.js",
   "private": false,
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes test failures on node v6.1.0