### PR TITLE
Set transaction hash on contract instantiation

### DIFF
--- a/classtemplate.js
+++ b/classtemplate.js
@@ -156,6 +156,7 @@ var Web3 = require("web3");
 
     instance.allEvents = contract.allEvents;
     instance.address = contract.address;
+    instance.transactionHash = contract.transactionHash;
   };
 
   // Use inheritance to create a clone of this contract,

--- a/test/contracts.js
+++ b/test/contracts.js
@@ -69,6 +69,12 @@ describe("Pudding + require", function() {
     done();
   });
 
+  it("should set the transaction hash of contract instantiation", function() {
+    return Example.new().then(function(example) {
+      assert(example.transactionHash, "transactionHash should be non-empty");
+    });
+  });
+
   it("should get and set values via methods and get values via .call", function(done) {
     var example;
     Example.new().then(function(instance) {


### PR DESCRIPTION
web3 sets the transaction hash on the contract instance. ether-pudding currently abandons the transaction hash instead of setting it on the pudding contract instance.

```js
// Deploy the contract asyncronous:
var myContractReturned = MyContract.new(param1, param2, {
   data: myContractCode,
   gas: 300000,
   from: mySenderAddress}, function(err, myContract){
    if(!err) {
       // NOTE: The callback will fire twice!
       // Once the contract has the transactionHash property set and once its deployed on an address.

       // e.g. check tx hash on the first call (transaction send)
       if(!myContract.address) {
           console.log(myContract.transactionHash) // The hash of the transaction, which deploys the contract

       // check address on the second call (contract deployed)
       } else {
           console.log(myContract.address) // the contract address
       }

       // Note that the returned "myContractReturned" === "myContract",
       // so the returned "myContractReturned" object will also get the address set.
    }
  });
```

https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethcontract