### PR TITLE
Remove undefined attempts variable completely

### DIFF
--- a/classtemplate.js
+++ b/classtemplate.js
@@ -113,8 +113,6 @@ var Web3 = require("web3");
                   return reject(new Error("Transaction " + tx + " wasn't processed in " + (timeout / 1000) + " seconds!"));
                 }
 
-                attempts += 1;
-
                 setTimeout(make_attempt, 1000);
               });
             };


### PR DESCRIPTION
Retries used to be managed using a number of attempts that gets incremented after each try.
4ce5aaa changed that to only using a timeout as pointed out in #31 

In the process, the `attempts` variable incrementation was left and now causes a bug.

This PR fixes that.