### PR TITLE
Fix call of synchronous network getter with asynchronous callback.

### DIFF
--- a/classtemplate.js
+++ b/classtemplate.js
@@ -355,7 +355,7 @@ var SolidityEvent = require("web3/lib/web3/event.js");
       return callback();
     }
 
-    this.web3.version.network(function(err, result) {
+    this.web3.version.getNetwork(function(err, result) {
       if (err) return callback(err);
 
       var network_id = result.toString();


### PR DESCRIPTION
Calling checkNetwork for contract classes generated by ether-pudding fail on trying to call synchronous network property asynchronously as a function. Changing it to getNetwork fixes the problem, I can try to find time to write some test if that is considered necessary.